### PR TITLE
fix: make the engines npm version >= 9 to fix an unsupported engine warning.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@mapbox/prettier-config-docs",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/prettier-config-docs",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "engines": {
         "node": ">=18",
-        "npm": "^9"
+        "npm": ">=9"
       },
       "peerDependencies": {
         "husky": "^8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/prettier-config-docs",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Prettier configuration for docs.mapbox.com sites",
   "main": "index.json",
   "scripts": {
@@ -30,6 +30,6 @@
   },
   "engines": {
     "node": ">=18",
-    "npm": "^9"
+    "npm": ">=9"
   }
 }


### PR DESCRIPTION
## context
When installing this package in projects using node 20, the following warning is shown since the `package.json` in this project locks the `npm` version to 9 even though the `node` version can be greater.

### example warning from `api-tilequery` when running `npm i`
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@mapbox/prettier-config-docs@2.1.0',
npm WARN EBADENGINE   required: { node: '>=18', npm: '^9' },
npm WARN EBADENGINE   current: { node: 'v20.11.0', npm: '10.2.4' }
npm WARN EBADENGINE }
```

## changes
* makes the `npm` engine version `>=9`
* bumps the package version to `2.1.1`