### PR TITLE
Disable embeddedLanguageFormatting in mdx files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ _or_ to extend this configuration to overwrite some properties, create `.prettie
 ```js
 module.exports = {
   ...require('@mapbox/prettier-config-docs'),
-  tabWidth: 4,
+  tabWidth: 4
 };
 ```
 
@@ -35,5 +35,3 @@ From the main branch:
 3. Run `mbx npm publish` to publish the package to npm.
 
 Dependabot will automatically update `@mapbox/prettier-config-docs` (within 1 day) to all site repositories. If you need it sooner, you can install this package in the repository by following the [install steps](#install).
-
-This package uses npm 7, which means it will automatically install the `peerDependnecies` found in `package.json`. If your site requires a different version of a peer dependency, you can install the dependency in your repository using the `--force ` flag. Example: `npm i prettier@2.0.0 --force`.

--- a/index.json
+++ b/index.json
@@ -8,6 +8,12 @@
       "options": {
         "quoteProps": "preserve"
       }
+    },
+    {
+      "files": "*.mdx",
+      "options": {
+        "embeddedLanguageFormatting": "off"
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR adds an override for all `.mdx` files, setting the [`embeddedLanguageFormatting`](https://prettier.io/docs/en/options#embedded-language-formatting) prettier rule to `off`.

This prevents prettier from removing new lines in markdown text when it is a child of a react component.  For example:

```
<Note title="What's new in v6?">
- _Secondary address support_ allows for retrieving apartment units and
business suites via forward geocoding, including those with coordinates unique
from their parent address.
- _Structured Input_ allows queries to be separated
into component parts for greater accuracy.
- _Smart Address Match_ makes the
`match_code` object available in all responses for address-type features, and
indicates how well a result corresponds to the submitted query.
- Improved
_Batch geocoding_ sends up to 1000 queries of mixed-type in a single request.
API rate limits still apply and each query will be counted as 1 request.
- Expanded _Japan coverage_ gives access to robust Japanese address search.
</Note>
```
would be reformatted to:

```
<Note title="What's new in v6?">
  - _Secondary address support_ allows for retrieving apartment units and
  business suites via forward geocoding, including those with coordinates unique
  from their parent address. - _Structured Input_ allows queries to be separated
  into component parts for greater accuracy. - _Smart Address Match_ makes the
  `match_code` object available in all responses for address-type features, and
  indicates how well a result corresponds to the submitted query. - Improved
  _Batch geocoding_ sends up to 1000 queries of mixed-type in a single request.
  API rate limits still apply and each query will be counted as 1 request. -
  Expanded _Japan coverage_ gives access to robust Japanese address search.
</Note>

```

Without the new lines, the unordered list is condensed into one list item (with the markdown hyphens treated as regular text)

Fixes https://mapbox.atlassian.net/jira/software/c/projects/MARKETING/boards/254?selectedIssue=MARKETING-3492