### PR TITLE
Update engines to node 20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.1.2",
       "license": "MIT",
       "engines": {
-        "node": ">=18",
-        "npm": ">=9"
+        "node": ">=20",
+        "npm": ">=10"
       },
       "peerDependencies": {
         "husky": "^8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "*.{json,md}": "prettier --write"
   },
   "engines": {
-    "node": ">=18",
-    "npm": ">=9"
+    "node": ">=20",
+    "npm": ">=10"
   }
 }


### PR DESCRIPTION
This PR updates engines in package.json to require Node >=20 and npm >=10.